### PR TITLE
[EOS] update encoding to text for commit_confim for ssh transport 

### DIFF
--- a/napalm/eos/eos.py
+++ b/napalm/eos/eos.py
@@ -530,7 +530,7 @@ class EOSDriver(NetworkDriver):
                 "configure session {} commit".format(self.config_session),
                 "write memory",
             ]
-            self._run_commands(commands)
+            self._run_commands(commands, encoding="text")
             self.config_session = None
         else:
             raise CommitError("No pending commit-confirm found!")


### PR DESCRIPTION
Tested confirm_commit on 4.28 EOS with ssh transport.  When you run confirm_commit on ssh transport, napalm produces invalid syntax to commit the config without 'text' encoding.

LOGS:
DEBUG:netmiko:write_channel: b'configure session napalm_142144 commit | json\n' DEBUG:netmiko:read_channel: 
DEBUG:netmiko:read_channel: configure session napalm_142144 commit | json % Invalid input

This PR is to address this issue.